### PR TITLE
Fixed PR-AZR-ARM-AKS-001: Azure CNI networking should be enabled in Azure AKS cluster

### DIFF
--- a/quickstarts/microsoft.containerinstance/aks-azml-targetcompute/azuredeploy.json
+++ b/quickstarts/microsoft.containerinstance/aks-azml-targetcompute/azuredeploy.json
@@ -2,7 +2,7 @@
     "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
-         "clusterName": {
+        "clusterName": {
             "type": "string",
             "metadata": {
                 "description": "The name of the Managed Cluster resource."
@@ -88,8 +88,8 @@
         }
     },
     "variables": {
-		 "dnsPrefix": "[parameters('clusterName')]"
-	},
+        "dnsPrefix": "[parameters('clusterName')]"
+    },
     "resources": [
         {
             "type": "Microsoft.ContainerService/managedClusters",
@@ -135,7 +135,7 @@
                 "nodeResourceGroup": "[concat('MC_', resourceGroup().name,'_', parameters('clusterName'), '_',parameters('location'))]",
                 "enableRBAC": true,
                 "networkProfile": {
-                    "networkPlugin": "kubenet",
+                    "networkPlugin": "azure",
                     "loadBalancerSku": "Basic",
                     "podCidr": "[parameters('podCidr')]",
                     "serviceCidr": "[parameters('serviceCidr')]",
@@ -165,4 +165,3 @@
         }
     ]
 }
-


### PR DESCRIPTION
**Violation Id:** PR-AZR-ARM-AKS-001 

 **Violation Description:** 

 Azure CNI provides the following features over kubenet networking:<br><br>- Every pod in the cluster is assigned an IP address in the virtual network. The pods can directly communicate with other pods in the cluster, and other nodes in the virtual network.<br>- Pods in a subnet that have service endpoints enabled can securely connect to Azure services, such as Azure Storage and SQL DB.<br>- You can create user-defined routes (UDR) to route traffic from pods to a Network Virtual Appliance.<br>- Support for Network Policies securing communication between pods.<br><br>This policy checks your AKS cluster for the Azure CNI network plugin and generates an alert if not found. 

 **How to Fix:** 

 Make sure you are following the ARM template guidelines for AKS by visiting <a href='https://docs.microsoft.com/en-us/azure/templates/microsoft.containerservice/managedclusters' target='_blank'>here</a>