### PR TITLE
Fixed PR-AZR-ARM-AKS-006: Managed Azure AD RBAC for AKS cluster should be enabled

### DIFF
--- a/quickstarts/microsoft.containerinstance/aks-advanced-networking/azuredeploy.json
+++ b/quickstarts/microsoft.containerinstance/aks-advanced-networking/azuredeploy.json
@@ -121,13 +121,13 @@
         "existingVirtualNetworkName": {
             "type": "string",
             "metadata": {
-              "description": "Name of an existing VNET that will contain this AKS deployment."
+                "description": "Name of an existing VNET that will contain this AKS deployment."
             }
         },
         "existingVirtualNetworkResourceGroup": {
             "type": "string",
             "metadata": {
-              "description": "Name of the existing VNET resource group"
+                "description": "Name of the existing VNET resource group"
             }
         },
         "existingSubnetName": {
@@ -159,15 +159,15 @@
         }
     },
     "variables": {
-        "builtInRole":{
-        "Owner":"[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')]",
-        "Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')]",
-        "Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'acdd72a7-3385-48ef-bd42-f606fba81ae7')]"
+        "builtInRole": {
+            "Owner": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')]",
+            "Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')]",
+            "Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'acdd72a7-3385-48ef-bd42-f606fba81ae7')]"
         },
         "vnetSubnetId": "[resourceId(parameters('existingVirtualNetworkResourceGroup'),'Microsoft.Network/virtualNetworks/subnets',parameters('existingVirtualNetworkName'),parameters('existingSubnetName'))]"
     },
     "resources": [
-            {
+        {
             "type": "Microsoft.Resources/deployments",
             "name": "ClusterSubnetRoleAssignmentDeployment",
             "apiVersion": "2019-10-01",
@@ -222,7 +222,7 @@
                         "storageProfile": "ManagedDisks",
                         "vnetSubnetID": "[variables('vnetSubnetID')]",
                         "maxPods": "[parameters('maxPods')]",
-                        "mode" : "System"
+                        "mode": "System"
                     }
                 ],
                 "servicePrincipalProfile": {
@@ -233,6 +233,10 @@
                     "serviceCidr": "[parameters('serviceCidr')]",
                     "dnsServiceIP": "[parameters('dnsServiceIP')]",
                     "dockerBridgeCidr": "[parameters('dockerBridgeCidr')]"
+                },
+                "aadProfile": {
+                    "managed": true,
+                    "enableAzureRBAC": true
                 }
             }
         }


### PR DESCRIPTION
**Violation Id:** PR-AZR-ARM-AKS-006 

 **Violation Description:** 

 Azure Kubernetes Service (AKS) can be configured to use Azure Active Directory (AD) for user authentication. In this configuration, you sign in to an AKS cluster using an Azure AD authentication token. You can also configure Kubernetes role-based access control (Kubernetes RBAC) to limit access to cluster resources based a user's identity or group membership. Visit https://docs.microsoft.com/en-us/azure/aks/azure-ad-rbac for details. 

 **How to Fix:** 

 Make sure aadProfile property of type object exist in ARM template with boolean managed = true and enableAzureRBAC = true as child property. Please visit <a href='https://docs.microsoft.com/en-us/azure/templates/microsoft.containerservice/managedclusters?tabs=json#managedclusteraadprofile-object' target='_blank'>here</a> for details.