### PR TITLE
Fixed PR-AZR-ARM-AKS-003: Azure AKS cluster monitoring should be enabled

### DIFF
--- a/application-workloads/minio/minio-azure-gateway/azuredeploy.json
+++ b/application-workloads/minio/minio-azure-gateway/azuredeploy.json
@@ -10,7 +10,9 @@
       }
     },
     "virtualNetworkAddressPrefix": {
-      "defaultValue": ["10.0.0.0/16"],
+      "defaultValue": [
+        "10.0.0.0/16"
+      ],
       "type": "array",
       "metadata": {
         "description": "VNET address space."
@@ -347,7 +349,11 @@
             "osDiskSizeGB": 80,
             "mode": "System",
             "type": "VirtualMachineScaleSets",
-            "availabilityZones": ["1", "2", "3"],
+            "availabilityZones": [
+              "1",
+              "2",
+              "3"
+            ],
             "vnetSubnetID": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('vnetName'), 'default')]"
           },
           {
@@ -363,7 +369,11 @@
             "enableAutoScaling": true,
             "minCount": "[parameters('mincount')]",
             "maxCount": "[parameters('maxcount')]",
-            "availabilityZones": ["1", "2", "3"],
+            "availabilityZones": [
+              "1",
+              "2",
+              "3"
+            ],
             "vnetSubnetID": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('vnetName'), 'default')]"
           }
         ],
@@ -375,6 +385,11 @@
                 "keyData": "[parameters('linuxSSHKey')]"
               }
             ]
+          }
+        },
+        "addonProfiles": {
+          "omsagent": {
+            "enabled": true
           }
         }
       }


### PR DESCRIPTION
**Violation Id:** PR-AZR-ARM-AKS-003 

 **Violation Description:** 

 Azure Monitor for containers gives you performance visibility by collecting memory and processor metrics from controllers, nodes, and containers that are available in Kubernetes through the Metrics API. Container logs are also collected. After you enable monitoring from Kubernetes clusters, metrics and logs are automatically collected for you through a containerized version of the Log Analytics agent for Linux. Metrics are written to the metrics store and log data is written to the logs store associated with your Log Analytics workspace. 

 **How to Fix:** 

 Make sure you are following the ARM template guidelines for AKS by visiting <a href='https://docs.microsoft.com/en-us/azure/templates/microsoft.containerservice/managedclusters' target='_blank'>here</a> for addonProfiles.omsagent.enabled