### PR TITLE
Fixed PR-AZR-ARM-AKS-004: Azure AKS cluster pool profile count should contain 3 nodes or more

### DIFF
--- a/application-workloads/jenkins/jenkins-cicd-container/azuredeploy.json
+++ b/application-workloads/jenkins/jenkins-cicd-container/azuredeploy.json
@@ -84,7 +84,7 @@
     },
     "kubernetesAgentCount": {
       "type": "int",
-      "defaultValue": 1,
+      "defaultValue": 3,
       "metadata": {
         "description": "The number of nodes for the cluster."
       },
@@ -386,4 +386,3 @@
     }
   }
 }
-


### PR DESCRIPTION
**Violation Id:** PR-AZR-ARM-AKS-004 

 **Violation Description:** 

 Ensure your AKS cluster pool profile count contains 3 or more nodes. This is recommended for a more resilient cluster. (Clusters smaller than 3 may experience downtime during upgrades.)<br><br>This policy checks the size of your cluster pool profiles and alerts if there are fewer than 3 nodes. 

 **How to Fix:** 

 Make sure you are following the ARM template guidelines for AKS by visiting <a href='https://docs.microsoft.com/en-us/azure/templates/microsoft.containerservice/managedclusters' target='_blank'>here</a>. Set minCount for Minimum number of nodes for auto-scaling to 3